### PR TITLE
Use newtonsoft library provided by Unity

### DIFF
--- a/Scripts/Attributes/Editor/ButtonDrawer.cs
+++ b/Scripts/Attributes/Editor/ButtonDrawer.cs
@@ -5,7 +5,7 @@ using UnityEditor;
 using UnityEngine;
 using System.Reflection;
 using System.Collections.Generic;
-using Unity.Plastic.Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace EditorAttributes.Editor
 {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
 	"changelogUrl": "https://editorattributesdocs.readthedocs.io/en/latest/changelogs.html",
 	"documentationUrl": "https://editorattributesdocs.readthedocs.io/",
 	
+	"dependencies": {
+		"com.unity.nuget.newtonsoft-json": "3.2.1"
+	},
+	
 	"keywords": 
 	[
 		"editor",


### PR DESCRIPTION
Hi

Very cool library you've made here. Don't know if you accept pull requests or just want to work on it by yourself, but I wanted you to have the opportunity to use the small fixes I made to make it work for me. If you don't want them - no problem, all good.

I had trouble finding and using the library Unity.Plastics.Newtonsoft.Json so I have replaced it with the version of Newtonsoft.Json that Unity has made public ([https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.2/manual/index.html](https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.2/manual/index.html)). I also added the library as a dependency.

Cheers