### PR TITLE
fix: trying to validate readonly scene files from other packages in the package cache

### DIFF
--- a/Editor/Scripts/EditorValidation.cs
+++ b/Editor/Scripts/EditorValidation.cs
@@ -44,12 +44,21 @@ namespace EditorAttributes.Editor
 		{
 			int failedValidations = 0;
 			int successfulValidations = 0;
+			int ignoredValidations = 0;
 
 			string[] sceneGuids = AssetDatabase.FindAssets("t:Scene");
 
 			foreach (var sceneGuid in sceneGuids)
 			{
 				string scenePath = AssetDatabase.GUIDToAssetPath(sceneGuid);
+
+				bool isReadOnly = scenePath.StartsWith("Packages/");
+				if (isReadOnly)
+				{
+					Debug.Log($"Scene at {scenePath} is read only, skipping");
+					ignoredValidations++;
+					continue;
+				}
 				var scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
 
 				ValidateScene(scene, ref failedValidations, ref successfulValidations);
@@ -58,7 +67,7 @@ namespace EditorAttributes.Editor
 					EditorSceneManager.CloseScene(scene, true);
 			}
 
-			Debug.Log($"Scenes Validated: <b>(Falied: {failedValidations}, Succeeded: {successfulValidations}, Total: {failedValidations + successfulValidations})</b>");
+			Debug.Log($"Scenes Validated: <b>(Failed: {failedValidations}, Succeeded: {successfulValidations}, Ignored: {ignoredValidations}, Total: {failedValidations + successfulValidations + ignoredValidations})</b>");
 		}
 
 		/// <summary>
@@ -90,7 +99,7 @@ namespace EditorAttributes.Editor
 				Validate(scriptableObject, ref failedValidations, ref successfulValidations);
 			}
 
-			Debug.Log($"Assets Validated: <b>(Falied: {failedValidations}, Succeeded: {successfulValidations}, Total: {failedValidations + successfulValidations})</b>");
+			Debug.Log($"Assets Validated: <b>(Failed: {failedValidations}, Succeeded: {successfulValidations}, Total: {failedValidations + successfulValidations})</b>");
 		}
 
 		/// <summary>


### PR DESCRIPTION
Addresses issue #13 

Not sure if this is the best way to go about it? But it does work with this check. Might be worth investigating a more permanent way to handle this with a try catch and using [AssetDatabase.IsOpenForEdit](https://docs.unity3d.com/ScriptReference/AssetDatabase.IsOpenForEdit.html) to verify if a scene is editable in the first place. 

I'm not really sure I understand what's going on with this scene validation logic in the first place, so perhaps there is another way to run the validation besides additively loading and unloading all scenes in the project.

Let me know if I should utilize the above mentioned approach, or if this crude check is enough!

Also fixed a small spelling mistake :3