### PR TITLE
Make OnValueChanged work with custom Serializable types

### DIFF
--- a/Editor/Scripts/Drawers/MiscellaneousAttributeDrawers/OnValueChangedDrawer.cs
+++ b/Editor/Scripts/Drawers/MiscellaneousAttributeDrawers/OnValueChangedDrawer.cs
@@ -11,7 +11,7 @@ namespace EditorAttributes.Editor
     	public override VisualElement CreatePropertyGUI(SerializedProperty property)
     	{
 			var onValueChangedAttribute = attribute as OnValueChangedAttribute;
-			var target = property.serializedObject.targetObject;
+			var target = property.GetContainingObject();
 
     		var root = new VisualElement();
 		    var propertyField = DrawProperty(property);

--- a/Editor/Scripts/Drawers/MiscellaneousAttributeDrawers/OnValueChangedDrawer.cs
+++ b/Editor/Scripts/Drawers/MiscellaneousAttributeDrawers/OnValueChangedDrawer.cs
@@ -11,7 +11,7 @@ namespace EditorAttributes.Editor
     	public override VisualElement CreatePropertyGUI(SerializedProperty property)
     	{
 			var onValueChangedAttribute = attribute as OnValueChangedAttribute;
-			var target = property.GetContainingObject();
+			ReflectionUtility.GetNestedObjectType(property, out object target);
 
     		var root = new VisualElement();
 		    var propertyField = DrawProperty(property);

--- a/Editor/Scripts/Utilities/ReflectionUtility.cs
+++ b/Editor/Scripts/Utilities/ReflectionUtility.cs
@@ -10,6 +10,27 @@ namespace EditorAttributes.Editor.Utility
     {
 		public const BindingFlags BINDING_FLAGS = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
 
+		#nullable  enable
+	    /// <summary>
+	    /// Gets object containing this SerializedProperty.
+	    /// </summary>
+	    /// <param name="property">SerializedProperty contained withing an instance.</param>
+	    /// <returns>Objects that contains given SerializedProperty.</returns>
+		public static object GetContainingObject(this SerializedProperty property) {
+			var pathParts = property.propertyPath.Split(".").SkipLast(1);
+			object currentObject = property.serializedObject.targetObject;
+
+			foreach (var part in pathParts) {
+				var field = currentObject
+					.GetType()
+					.GetField(part, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+				currentObject = field.GetValue(currentObject);
+			}
+
+			return currentObject;
+		}
+		#nullable disable
+		
 		/// <summary>
 		/// Finds a field inside a serialized object
 		/// </summary>

--- a/Editor/Scripts/Utilities/ReflectionUtility.cs
+++ b/Editor/Scripts/Utilities/ReflectionUtility.cs
@@ -15,7 +15,7 @@ namespace EditorAttributes.Editor.Utility
 	    /// Gets object containing this SerializedProperty.
 	    /// </summary>
 	    /// <param name="property">SerializedProperty contained withing an instance.</param>
-	    /// <returns>Objects that contains given SerializedProperty.</returns>
+	    /// <returns>Object that contains given SerializedProperty.</returns>
 		public static object? GetContainingObject(this SerializedProperty property) {
 			var pathParts = property.propertyPath.Split(".").SkipLast(1);
 			object currentObject = property.serializedObject.targetObject;

--- a/Editor/Scripts/Utilities/ReflectionUtility.cs
+++ b/Editor/Scripts/Utilities/ReflectionUtility.cs
@@ -9,30 +9,6 @@ namespace EditorAttributes.Editor.Utility
 	public static class ReflectionUtility
     {
 		public const BindingFlags BINDING_FLAGS = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
-
-		#nullable  enable
-	    /// <summary>
-	    /// Gets object containing this SerializedProperty.
-	    /// </summary>
-	    /// <param name="property">SerializedProperty contained withing an instance.</param>
-	    /// <returns>Object that contains given SerializedProperty.</returns>
-		public static object? GetContainingObject(this SerializedProperty property) {
-			var pathParts = property.propertyPath.Split(".").SkipLast(1);
-			object currentObject = property.serializedObject.targetObject;
-
-			foreach (var part in pathParts) {
-				var field = currentObject
-					.GetType()
-					.GetField(part, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-
-				if (field == null) return null;
-				
-				currentObject = field.GetValue(currentObject);
-			}
-
-			return currentObject;
-		}
-		#nullable disable
 		
 		/// <summary>
 		/// Finds a field inside a serialized object
@@ -92,7 +68,8 @@ namespace EditorAttributes.Editor.Utility
 		{
 			MethodInfo methodInfo;
 
-			methodInfo = FindFunction(functionName, property.GetContainingObject());
+			GetNestedObjectType(property, out object target);
+			methodInfo = FindFunction(functionName, target);
 
 			// If the method is null we try to see if its inside a serialized object
 			if (methodInfo == null)

--- a/Editor/Scripts/Utilities/ReflectionUtility.cs
+++ b/Editor/Scripts/Utilities/ReflectionUtility.cs
@@ -67,7 +67,7 @@ namespace EditorAttributes.Editor.Utility
 		public static MethodInfo FindFunction(string functionName, SerializedProperty property)
 		{
 			MethodInfo methodInfo;
-			
+
 			methodInfo = FindFunction(functionName, property.serializedObject.targetObject);
 
 			// If the method is null we try to see if its inside a serialized object

--- a/Editor/Scripts/Utilities/ReflectionUtility.cs
+++ b/Editor/Scripts/Utilities/ReflectionUtility.cs
@@ -92,7 +92,7 @@ namespace EditorAttributes.Editor.Utility
 		{
 			MethodInfo methodInfo;
 
-			methodInfo = FindFunction(functionName, property.serializedObject.targetObject);
+			methodInfo = FindFunction(functionName, property.GetContainingObject());
 
 			// If the method is null we try to see if its inside a serialized object
 			if (methodInfo == null)

--- a/Editor/Scripts/Utilities/ReflectionUtility.cs
+++ b/Editor/Scripts/Utilities/ReflectionUtility.cs
@@ -9,7 +9,7 @@ namespace EditorAttributes.Editor.Utility
 	public static class ReflectionUtility
     {
 		public const BindingFlags BINDING_FLAGS = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
-		
+
 		/// <summary>
 		/// Finds a field inside a serialized object
 		/// </summary>
@@ -67,9 +67,8 @@ namespace EditorAttributes.Editor.Utility
 		public static MethodInfo FindFunction(string functionName, SerializedProperty property)
 		{
 			MethodInfo methodInfo;
-
-			GetNestedObjectType(property, out object target);
-			methodInfo = FindFunction(functionName, target);
+			
+			methodInfo = FindFunction(functionName, property.serializedObject.targetObject);
 
 			// If the method is null we try to see if its inside a serialized object
 			if (methodInfo == null)

--- a/Editor/Scripts/Utilities/ReflectionUtility.cs
+++ b/Editor/Scripts/Utilities/ReflectionUtility.cs
@@ -16,7 +16,7 @@ namespace EditorAttributes.Editor.Utility
 	    /// </summary>
 	    /// <param name="property">SerializedProperty contained withing an instance.</param>
 	    /// <returns>Objects that contains given SerializedProperty.</returns>
-		public static object GetContainingObject(this SerializedProperty property) {
+		public static object? GetContainingObject(this SerializedProperty property) {
 			var pathParts = property.propertyPath.Split(".").SkipLast(1);
 			object currentObject = property.serializedObject.targetObject;
 
@@ -24,6 +24,9 @@ namespace EditorAttributes.Editor.Utility
 				var field = currentObject
 					.GetType()
 					.GetField(part, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+				if (field == null) return null;
+				
 				currentObject = field.GetValue(currentObject);
 			}
 


### PR DESCRIPTION
Fixes the #18 issue.

Currently it's assumed that property.serializedObject.targetObject always returns an object containing the function passed to the OnValueChangedAttribute by name, but it can be an object "above". 
Like in the following example property.serializedObject.targetObject  returns instance of SerializeCustomSerializable, instead of instance of CustomSerializable that contains target function:
```csharp
using System;
using EditorAttributes;
using UnityEngine;

[Serializable]
public class CustomSerializable {
    [SerializeField]
    [OnValueChanged(nameof(OnValue))]
    private float s;

    private void OnValue() {
        Debug.Log("Changed!");
    }
}

public class SerializeCustomSerializable : MonoBehaviour {
    [SerializeField] private CustomSerializable cs;
}
```

I used property.propertyPath to trace the target object. Not sure whether it's the most appropriate way to do this.