### PR TITLE
Added ability to validate addressable scenes

### DIFF
--- a/Editor/Scripts/EditorAttributes.Editor.asmdef
+++ b/Editor/Scripts/EditorAttributes.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "EditorAttributes.Editor",
     "rootNamespace": "EditorAttributes.Editor",
     "references": [
-        "GUID:febaf25a60dafbd44941357b21678606"
+        "GUID:febaf25a60dafbd44941357b21678606",
+        "GUID:69448af7b92c7f342b298e06a37122aa"
     ],
     "includePlatforms": [
         "Editor"
@@ -13,6 +14,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.addressables",
+            "expression": "2.2.2",
+            "define": "USE_ADDRESSABLES"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Editor/Scripts/EditorValidation.cs
+++ b/Editor/Scripts/EditorValidation.cs
@@ -25,7 +25,7 @@ namespace EditorAttributes.Editor
 		public void OnPreprocessBuild(BuildReport report)
 		{
 			BUILD_KILLERS = 0;
-
+ 
 			if (!DISABLE_BUILD_VALIDATION)
 				ValidateAll();
 
@@ -69,8 +69,8 @@ namespace EditorAttributes.Editor
 			{
 				string scenePath = AssetDatabase.GUIDToAssetPath(sceneGuid);
 
-				if (IsPackageAsset(scenePath) || SceneUtility.GetBuildIndexByScenePath(scenePath) == -1)
-					continue;
+				if (IsPackageAsset(scenePath)) continue;
+				if (SceneUtility.GetBuildIndexByScenePath(scenePath) == -1 && !IsAddressable(sceneGuid)) continue;
 
 				var openedScene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
 
@@ -81,6 +81,27 @@ namespace EditorAttributes.Editor
 			}
 
 			Debug.Log($"Scenes Validated: <b>(Failed: {failedValidations}, Succeeded: {successfulValidations}, Total: {failedValidations + successfulValidations})</b>");
+		}
+
+		private static bool IsAddressable(string guid)
+		{
+#if USE_ADDRESSABLES
+			var settings = UnityEditor.AddressableAssets.AddressableAssetSettingsDefaultObject.Settings;
+			foreach (var group in settings.groups)
+			{
+				if (group == null || group.entries.Count == 0) 
+					continue;
+
+				foreach (var entry in group.entries)
+				{
+					if (entry.guid == guid)
+					{
+						return true;
+					}
+				}
+			}
+#endif
+			return false;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Validation in this package is good and simple to use, but it provides only basic scene validation API based on building settings. This approach wont work for advanced project structure with Addressable scenes separate on different groups.

Extra check for scene validation method was added to include addressable scene in validation process.
Addressables support was added as Define on amsdef file and GUID reference, so this change does not affect users without Addressables.