### PR TITLE
Unit Field Attribute updates/fixes

### DIFF
--- a/Editor/Scripts/Drawers/NumericalAttributeDrawers/UnitFieldDrawer.cs
+++ b/Editor/Scripts/Drawers/NumericalAttributeDrawers/UnitFieldDrawer.cs
@@ -66,10 +66,9 @@ namespace EditorAttributes.Editor
                         var suffix = new Label(convertedUnit.unitLabel);
                         suffix.tooltip = unitFieldAttribute.DisplayUnit;
                         suffix.style.color = textCopy.style.color;
-                        suffix.style.fontSize = 10;
                         suffix.style.unityFontDefinition = textCopy.style.unityFontDefinition;
                         suffix.style.opacity = 0.5f;
-                        suffix.style.unityTextAlign = TextAnchor.MiddleLeft;
+                        suffix.style.unityTextAlign = TextAnchor.MiddleRight;
                         suffix.style.flexGrow = 1;
                         suffix.style.flexShrink = 1;
                         suffix.style.paddingLeft = 1;

--- a/Editor/Scripts/Drawers/NumericalAttributeDrawers/UnitFieldDrawer.cs
+++ b/Editor/Scripts/Drawers/NumericalAttributeDrawers/UnitFieldDrawer.cs
@@ -27,8 +27,12 @@ namespace EditorAttributes.Editor
             }
 
             // Wait for Unity fields to be setup.
-            root.RegisterCallbackOnce<GeometryChangedEvent>((changeEvent) =>
+            root.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+
+            void OnGeometryChanged(GeometryChangedEvent changeEvent)
             {
+                root.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+
                 root.Query<BindableElement>(className: TextInputBaseField<Void>.ussClassName).ForEach((element) =>
                 {
                     // This will query into all types that implement these numerics.
@@ -74,7 +78,7 @@ namespace EditorAttributes.Editor
                         textCopy.parent.Add(suffix);
                     }, 25);
                 });
-            });
+            }
 
             return root;
         }

--- a/Editor/Scripts/Drawers/NumericalAttributeDrawers/UnitFieldDrawer.cs
+++ b/Editor/Scripts/Drawers/NumericalAttributeDrawers/UnitFieldDrawer.cs
@@ -82,6 +82,9 @@ namespace EditorAttributes.Editor
             return root;
         }
 
+        // NOTE: TrackPropertyValue is used to sync value changes from
+        // non-inspector sources back to the inspector (like a script
+        // that changes values in OnValidate).
         private VisualElement CreateFieldCopy(BindableElement element, SerializedProperty property, UnitFieldAttribute unitFieldAttribute)
         {
             UnitConverter convertedUnit = GetConversion();
@@ -92,7 +95,7 @@ namespace EditorAttributes.Editor
 
                 var floatFieldCopy = CreateFieldForType<float>(floatField.label, (float)(floatField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as FloatField;
                 floatFieldCopy.RegisterValueChangedCallback((changeEvent) => floatField.value = (float)(floatFieldCopy.value * GetConversion().conversion));
-                floatField.TrackPropertyValue(property, (property) => floatFieldCopy.SetValueWithoutNotify((float)(floatField.value / GetConversion().conversion)));
+                //floatField.TrackPropertyValue(property, (property) => floatFieldCopy.SetValueWithoutNotify((float)(floatField.value / GetConversion().conversion)));
                 return floatFieldCopy;
             }
             else if (element is DoubleField)
@@ -101,7 +104,7 @@ namespace EditorAttributes.Editor
 
                 var doubleFieldCopy = CreateFieldForType<double>(doubleField.label, doubleField.value / convertedUnit.conversion, property.hasMultipleDifferentValues) as DoubleField;
                 doubleFieldCopy.RegisterValueChangedCallback((changeEvent) => doubleField.value = doubleFieldCopy.value * GetConversion().conversion);
-                doubleField.TrackPropertyValue(property, (property) => doubleFieldCopy.SetValueWithoutNotify(doubleField.value / GetConversion().conversion));
+                //doubleField.TrackPropertyValue(property, (property) => doubleFieldCopy.SetValueWithoutNotify(doubleField.value / GetConversion().conversion));
                 return doubleFieldCopy;
             }
             else if (element is IntegerField)
@@ -110,7 +113,7 @@ namespace EditorAttributes.Editor
 
                 var integerFieldCopy = CreateFieldForType<int>(integerField.label, (int)(integerField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as IntegerField;
                 integerFieldCopy.RegisterValueChangedCallback((changeEvent) => integerField.value = (int)(integerFieldCopy.value * GetConversion().conversion));
-                integerField.TrackPropertyValue(property, (property) => integerFieldCopy.SetValueWithoutNotify((int)(integerField.value / GetConversion().conversion)));
+                //integerField.TrackPropertyValue(property, (property) => integerFieldCopy.SetValueWithoutNotify((int)(integerField.value / GetConversion().conversion)));
                 return integerFieldCopy;
             }
             else if (element is UnsignedIntegerField)
@@ -119,7 +122,7 @@ namespace EditorAttributes.Editor
 
                 var unsignedIntegerFieldCopy = CreateFieldForType<uint>(unsignedIntegerField.label, (uint)(unsignedIntegerField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as UnsignedIntegerField;
                 unsignedIntegerFieldCopy.RegisterValueChangedCallback((changeEvent) => unsignedIntegerField.value = (uint)(unsignedIntegerFieldCopy.value * GetConversion().conversion));
-                unsignedIntegerField.TrackPropertyValue(property, (property) => unsignedIntegerFieldCopy.SetValueWithoutNotify((uint)(unsignedIntegerField.value / GetConversion().conversion)));
+                //unsignedIntegerField.TrackPropertyValue(property, (property) => unsignedIntegerFieldCopy.SetValueWithoutNotify((uint)(unsignedIntegerField.value / GetConversion().conversion)));
                 return unsignedIntegerFieldCopy;
             }
             else if (element is LongField)
@@ -128,7 +131,7 @@ namespace EditorAttributes.Editor
 
                 var longFieldCopy = CreateFieldForType<long>(longField.label, (long)(longField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as LongField;
                 longFieldCopy.RegisterValueChangedCallback((changeEvent) => longField.value = (long)(longFieldCopy.value * GetConversion().conversion));
-                longField.TrackPropertyValue(property, (property) => longFieldCopy.SetValueWithoutNotify((long)(longField.value / GetConversion().conversion)));
+                //longField.TrackPropertyValue(property, (property) => longFieldCopy.SetValueWithoutNotify((long)(longField.value / GetConversion().conversion)));
                 return longFieldCopy;
             }
             else if (element is UnsignedLongField)
@@ -137,7 +140,7 @@ namespace EditorAttributes.Editor
 
                 var unsignedLongFieldCopy = CreateFieldForType<ulong>(unsignedLongField.label, (ulong)(unsignedLongField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as UnsignedLongField;
                 unsignedLongFieldCopy.RegisterValueChangedCallback((changeEvent) => unsignedLongField.value = (ulong)(unsignedLongFieldCopy.value * GetConversion().conversion));
-                unsignedLongField.TrackPropertyValue(property, (property) => unsignedLongFieldCopy.SetValueWithoutNotify((ulong)(unsignedLongField.value / GetConversion().conversion)));
+                //unsignedLongField.TrackPropertyValue(property, (property) => unsignedLongFieldCopy.SetValueWithoutNotify((ulong)(unsignedLongField.value / GetConversion().conversion)));
                 return unsignedLongFieldCopy;
             }
             else

--- a/Editor/Scripts/Drawers/NumericalAttributeDrawers/UnitFieldDrawer.cs
+++ b/Editor/Scripts/Drawers/NumericalAttributeDrawers/UnitFieldDrawer.cs
@@ -93,6 +93,9 @@ namespace EditorAttributes.Editor
 
             Type fieldType = GetFieldType(element, FieldMask.Numeric);
 
+            if (fieldType == null)
+                return null;
+
             var elementCopy = CreateFieldForType(fieldType, GetFieldLabel(element), Convert.ChangeType(Convert.ToDouble(GetFieldValue(element)) / convertedUnit.conversion, fieldType), property.hasMultipleDifferentValues);
             RegisterValueChangedCallbackByType(fieldType, elementCopy, (changeEvent) => SetFieldValue(element, Convert.ChangeType(Convert.ToDouble(GetFieldValue(elementCopy)) * GetConversion().conversion, fieldType), true));
             element.TrackPropertyValue(property, (property) => SetFieldValue(elementCopy, Convert.ChangeType(Convert.ToDouble(GetFieldValue(element)) / GetConversion().conversion, fieldType)));

--- a/Editor/Scripts/Drawers/NumericalAttributeDrawers/UnitFieldDrawer.cs
+++ b/Editor/Scripts/Drawers/NumericalAttributeDrawers/UnitFieldDrawer.cs
@@ -1,5 +1,6 @@
-using System;
+using System.Linq;
 using UnityEditor;
+using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -12,234 +13,205 @@ namespace EditorAttributes.Editor
 		{
 			var unitFieldAttribute = attribute as UnitFieldAttribute;
 
-			var root = new VisualElement();
-			var errorBox = new HelpBox();
+            var root = CreatePropertyField(property);
 
-			var convertedUnit = UnitConverter.GetConversion(unitFieldAttribute.DisplayUnit, unitFieldAttribute.ConversionUnit);
+            var convertedUnit = UnitConverter.GetConversion(unitFieldAttribute.DisplayUnit, unitFieldAttribute.ConversionUnit);
 
-			if (convertedUnit == null)
-			{
-				errorBox.text = $"No conversion found for <b>{unitFieldAttribute.DisplayUnit}</b> to <b>{unitFieldAttribute.ConversionUnit}</b>. You can add custom conversions in the <b>ProjectSettings/EditorAttributes</b> window";
+            if (convertedUnit == null)
+            {
+                var errorBox = new HelpBox();
+                errorBox.text = $"No conversion found for <b>{unitFieldAttribute.DisplayUnit}</b> to <b>{unitFieldAttribute.ConversionUnit}</b>. You can add custom conversions in the <b>ProjectSettings/EditorAttributes</b> window";
 
-				DisplayErrorBox(root, errorBox);
-				return root;
-			}
+                DisplayErrorBox(root, errorBox);
+                return root;
+            }
 
-			if (IsSupportedType(property.propertyType))
-			{
-				var propertyValue = GetConvertedPropertyValue(property, convertedUnit.conversion);
-				var numericType = GetFieldNumericType(property);
+            // Wait for Unity fields to be setup.
+            root.RegisterCallbackOnce<GeometryChangedEvent>((changeEvent) =>
+            {
+                root.Query<BindableElement>(className: TextInputBaseField<Void>.ussClassName).ForEach((element) =>
+                {
+                    // This will query into all types that implement these numerics.
+                    // For example, the Unit attribute will also work with the three
+                    // float inputs in a Vector3 property drawer.
+                    //
+                    // We create the field copy after 25ms because otherwise the built
+                    // in property field automatically cleans manually created elements.
+                    ExecuteLater(root, () =>
+                    {
+                        var fieldCopy = CreateFieldCopy(element, property, unitFieldAttribute);
 
-				var numericField = CreateFieldForType(numericType, property.displayName, propertyValue, property.hasMultipleDifferentValues);
+                        if (fieldCopy == null)
+                            return;
 
-				numericField.AddToClassList(BaseField<Void>.alignedFieldUssClassName);
+                        element.style.display = DisplayStyle.None;
+                        element.parent.Add(fieldCopy);
+                        fieldCopy.PlaceInFront(element);
 
-				RegisterValueChangedCallbackByType(numericType, numericField, (value) =>
-				{
-					convertedUnit = UnitConverter.GetConversion(unitFieldAttribute.DisplayUnit, unitFieldAttribute.ConversionUnit);
+                        var children = element.Query().Build();
+                        var childrenCopies = fieldCopy.Query().Build();
 
-					SetNumericPropertyValue(property, value, convertedUnit.conversion);
-				});
+                        for (int i = 0; i < children.Count(); i++)
+                            CopyStyle(childrenCopies.AtIndex(i), children.AtIndex(i));
 
-				root.Add(numericField);
+                        var textCopy = fieldCopy.Q<TextElement>(className: TextElement.selectableUssClassName);
 
-				ExecuteLater(numericField, () =>
-				{
-					var inputLabels = numericField.Query<VisualElement>(TextInputBaseField<Void>.textInputUssName).ToList();
+                        textCopy.style.flexGrow = 0;
+                        textCopy.style.flexShrink = 1;
 
-					foreach (var inputLabel in inputLabels)
-					{
-						var unitLabel = new Label(convertedUnit.unitLabel)
-						{
-							tooltip = unitFieldAttribute.DisplayUnit,
-							style =
-							{
-								unityTextAlign = TextAnchor.MiddleRight,
-								color = Color.gray,
-							}
-						};
+                        var suffix = new Label(convertedUnit.unitLabel);
+                        suffix.tooltip = unitFieldAttribute.DisplayUnit;
+                        suffix.style.color = textCopy.style.color;
+                        suffix.style.fontSize = 10;
+                        suffix.style.unityFontDefinition = textCopy.style.unityFontDefinition;
+                        suffix.style.opacity = 0.5f;
+                        suffix.style.unityTextAlign = TextAnchor.MiddleLeft;
+                        suffix.style.flexGrow = 1;
+                        suffix.style.flexShrink = 1;
+                        suffix.style.paddingLeft = 1;
+                        suffix.focusable = false;
 
-						inputLabel.Add(unitLabel);
-					}
-				});
-			}
-			else
-			{
-				errorBox.text = "The UnitField Attribute can only be attached to numeric types";
-			}
+                        textCopy.parent.Add(suffix);
+                    }, 25);
+                });
+            });
 
-			DisplayErrorBox(root, errorBox);
+            return root;
+        }
 
-			return root;
-		}
+        private VisualElement CreateFieldCopy(BindableElement element, SerializedProperty property, UnitFieldAttribute unitFieldAttribute)
+        {
+            UnitConverter convertedUnit = GetConversion();
 
-		private Type GetFieldNumericType(SerializedProperty property) => property.numericType switch
-		{
-			SerializedPropertyNumericType.Int32 => typeof(int),
-			SerializedPropertyNumericType.Int64 => typeof(long),
-			SerializedPropertyNumericType.UInt32 => typeof(uint),
-			SerializedPropertyNumericType.UInt64 => typeof(ulong),
-			SerializedPropertyNumericType.Float => typeof(float),
-			SerializedPropertyNumericType.Double => typeof(double),
-			_ => property.propertyType switch
-			{
-				SerializedPropertyType.Vector2 => typeof(Vector2),
-				SerializedPropertyType.Vector3 => typeof(Vector3),
-				SerializedPropertyType.Vector4 => typeof(Vector4),
-				SerializedPropertyType.Rect => typeof(Rect),
-				SerializedPropertyType.Vector2Int => typeof(Vector2Int),
-				SerializedPropertyType.Vector3Int => typeof(Vector3Int),
-				SerializedPropertyType.RectInt => typeof(RectInt),
-				_ => null,
-			}
-		};
+            if (element is FloatField)
+            {
+                FloatField floatField = element as FloatField;
 
-		private object GetConvertedPropertyValue(SerializedProperty property, double conversion)
-		{
-			// Invert the conversion factor to go from base -> converted unit
-			double displayFactor = 1.0d / conversion;
+                var floatFieldCopy = CreateFieldForType<float>(floatField.label, (float)(floatField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as FloatField;
+                floatFieldCopy.RegisterValueChangedCallback((changeEvent) => floatField.value = (float)(floatFieldCopy.value * GetConversion().conversion));
+                floatField.TrackPropertyValue(property, (property) => floatFieldCopy.SetValueWithoutNotify((float)(floatField.value / GetConversion().conversion)));
+                return floatFieldCopy;
+            }
+            else if (element is DoubleField)
+            {
+                DoubleField doubleField = element as DoubleField;
 
-			return property.numericType switch
-			{
-				SerializedPropertyNumericType.Float => property.floatValue * (float)displayFactor,
-				SerializedPropertyNumericType.Double => property.doubleValue * displayFactor,
-				SerializedPropertyNumericType.Int32 => (int)(property.intValue * displayFactor),
-				SerializedPropertyNumericType.Int64 => (long)(property.longValue * displayFactor),
-				SerializedPropertyNumericType.UInt32 => (uint)(property.uintValue * displayFactor),
-				SerializedPropertyNumericType.UInt64 => (ulong)(property.ulongValue * displayFactor),
+                var doubleFieldCopy = CreateFieldForType<double>(doubleField.label, doubleField.value / convertedUnit.conversion, property.hasMultipleDifferentValues) as DoubleField;
+                doubleFieldCopy.RegisterValueChangedCallback((changeEvent) => doubleField.value = doubleFieldCopy.value * GetConversion().conversion);
+                doubleField.TrackPropertyValue(property, (property) => doubleFieldCopy.SetValueWithoutNotify(doubleField.value / GetConversion().conversion));
+                return doubleFieldCopy;
+            }
+            else if (element is IntegerField)
+            {
+                IntegerField integerField = element as IntegerField;
 
-				_ => property.propertyType switch
-				{
-					SerializedPropertyType.Vector2 => new Vector2(
-						property.vector2Value.x * (float)displayFactor,
-						property.vector2Value.y * (float)displayFactor
-					),
+                var integerFieldCopy = CreateFieldForType<int>(integerField.label, (int)(integerField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as IntegerField;
+                integerFieldCopy.RegisterValueChangedCallback((changeEvent) => integerField.value = (int)(integerFieldCopy.value * GetConversion().conversion));
+                integerField.TrackPropertyValue(property, (property) => integerFieldCopy.SetValueWithoutNotify((int)(integerField.value / GetConversion().conversion)));
+                return integerFieldCopy;
+            }
+            else if (element is UnsignedIntegerField)
+            {
+                UnsignedIntegerField unsignedIntegerField = element as UnsignedIntegerField;
 
-					SerializedPropertyType.Vector3 => new Vector3(
-						property.vector3Value.x * (float)displayFactor,
-						property.vector3Value.y * (float)displayFactor,
-						property.vector3Value.z * (float)displayFactor
-					),
+                var unsignedIntegerFieldCopy = CreateFieldForType<uint>(unsignedIntegerField.label, (uint)(unsignedIntegerField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as UnsignedIntegerField;
+                unsignedIntegerFieldCopy.RegisterValueChangedCallback((changeEvent) => unsignedIntegerField.value = (uint)(unsignedIntegerFieldCopy.value * GetConversion().conversion));
+                unsignedIntegerField.TrackPropertyValue(property, (property) => unsignedIntegerFieldCopy.SetValueWithoutNotify((uint)(unsignedIntegerField.value / GetConversion().conversion)));
+                return unsignedIntegerFieldCopy;
+            }
+            else if (element is LongField)
+            {
+                LongField longField = element as LongField;
 
-					SerializedPropertyType.Vector4 => new Vector4(
-						property.vector4Value.x * (float)displayFactor,
-						property.vector4Value.y * (float)displayFactor,
-						property.vector4Value.z * (float)displayFactor,
-						property.vector4Value.w * (float)displayFactor
-					),
+                var longFieldCopy = CreateFieldForType<long>(longField.label, (long)(longField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as LongField;
+                longFieldCopy.RegisterValueChangedCallback((changeEvent) => longField.value = (long)(longFieldCopy.value * GetConversion().conversion));
+                longField.TrackPropertyValue(property, (property) => longFieldCopy.SetValueWithoutNotify((long)(longField.value / GetConversion().conversion)));
+                return longFieldCopy;
+            }
+            else if (element is UnsignedLongField)
+            {
+                UnsignedLongField unsignedLongField = element as UnsignedLongField;
 
-					SerializedPropertyType.Rect => new Rect(
-						property.rectValue.x * (float)displayFactor,
-						property.rectValue.y * (float)displayFactor,
-						property.rectValue.width * (float)displayFactor,
-						property.rectValue.height * (float)displayFactor
-					),
+                var unsignedLongFieldCopy = CreateFieldForType<ulong>(unsignedLongField.label, (ulong)(unsignedLongField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as UnsignedLongField;
+                unsignedLongFieldCopy.RegisterValueChangedCallback((changeEvent) => unsignedLongField.value = (ulong)(unsignedLongFieldCopy.value * GetConversion().conversion));
+                unsignedLongField.TrackPropertyValue(property, (property) => unsignedLongFieldCopy.SetValueWithoutNotify((ulong)(unsignedLongField.value / GetConversion().conversion)));
+                return unsignedLongFieldCopy;
+            }
+            else
+                return null;
 
-					SerializedPropertyType.Vector2Int => new Vector2Int(
-						(int)(property.vector2IntValue.x * displayFactor),
-						(int)(property.vector2IntValue.y * displayFactor)
-					),
+            UnitConverter GetConversion() => UnitConverter.GetConversion(unitFieldAttribute.DisplayUnit, unitFieldAttribute.ConversionUnit);
+        }
 
-					SerializedPropertyType.Vector3Int => new Vector3Int(
-						(int)(property.vector3IntValue.x * displayFactor),
-						(int)(property.vector3IntValue.y * displayFactor),
-						(int)(property.vector3IntValue.z * displayFactor)
-					),
-
-					SerializedPropertyType.RectInt => new RectInt(
-						(int)(property.rectIntValue.x * displayFactor),
-						(int)(property.rectIntValue.y * displayFactor),
-						(int)(property.rectIntValue.width * displayFactor),
-						(int)(property.rectIntValue.height * displayFactor)
-					),
-					_ => null
-				}
-			};
-		}
-
-		private void SetNumericPropertyValue(SerializedProperty property, object value, double conversion)
-		{
-			double convertedValue = 0d;
-
-			try
-			{
-				convertedValue = Convert.ToDouble(value) * conversion;
-			}
-			catch (InvalidCastException) { } // If this is thrown then it means that the value is a vector or rect type, which we handle separately
-
-			switch (property.numericType)
-			{
-				case SerializedPropertyNumericType.Float:
-					property.floatValue = (float)convertedValue;
-					break;
-
-				case SerializedPropertyNumericType.Double:
-					property.doubleValue = convertedValue;
-					break;
-
-				case SerializedPropertyNumericType.Int32:
-					property.intValue = (int)convertedValue;
-					break;
-
-				case SerializedPropertyNumericType.Int64:
-					property.longValue = (long)convertedValue;
-					break;
-
-				case SerializedPropertyNumericType.UInt32:
-					property.uintValue = (uint)convertedValue;
-					break;
-
-				case SerializedPropertyNumericType.UInt64:
-					property.ulongValue = (ulong)convertedValue;
-					break;
-
-				default:
-					switch (property.propertyType)
-					{
-						case SerializedPropertyType.Vector2:
-							var vector2Value = (Vector2)value;
-							property.vector2Value = new Vector2(vector2Value.x * (float)conversion, vector2Value.y * (float)conversion);
-							break;
-
-						case SerializedPropertyType.Vector3:
-							var vector3Value = (Vector3)value;
-							property.vector3Value = new Vector3(vector3Value.x * (float)conversion, vector3Value.y * (float)conversion, vector3Value.z * (float)conversion);
-							break;
-
-						case SerializedPropertyType.Vector4:
-							var vector4Value = (Vector4)value;
-							property.vector4Value = new Vector4(vector4Value.x * (float)conversion, vector4Value.y * (float)conversion, vector4Value.z * (float)conversion, vector4Value.w * (float)conversion);
-							break;
-
-						case SerializedPropertyType.Rect:
-							var rectValue = (Rect)value;
-							property.rectValue = new Rect(rectValue.x * (float)conversion, rectValue.y * (float)conversion, rectValue.width * (float)conversion, rectValue.height * (float)conversion);
-							break;
-
-						case SerializedPropertyType.Vector2Int:
-							var vector2IntValue = (Vector2Int)value;
-							property.vector2IntValue = new Vector2Int((int)(vector2IntValue.x * conversion), (int)(vector2IntValue.y * conversion));
-							break;
-
-						case SerializedPropertyType.Vector3Int:
-							var vector3IntValue = (Vector3Int)value;
-							property.vector3IntValue = new Vector3Int((int)(vector3IntValue.x * conversion), (int)(vector3IntValue.y * conversion), (int)(vector3IntValue.z * conversion));
-							break;
-
-						case SerializedPropertyType.RectInt:
-							var rectIntValue = (RectInt)value;
-							property.rectIntValue = new RectInt((int)(rectIntValue.x * conversion), (int)(rectIntValue.y * conversion), (int)(rectIntValue.width * conversion), (int)(rectIntValue.height * conversion));
-							break;
-					}
-					break;
-			}
-
-			property.serializedObject.ApplyModifiedProperties();
-		}
-
-		private bool IsSupportedType(SerializedPropertyType propertyType) => propertyType is SerializedPropertyType.Float or SerializedPropertyType.Integer
-			or SerializedPropertyType.Vector2 or SerializedPropertyType.Vector3 or SerializedPropertyType.Vector4
-			or SerializedPropertyType.Rect or SerializedPropertyType.RectInt
-			or SerializedPropertyType.Vector2Int or SerializedPropertyType.Vector3Int;
-	}
+        private void CopyStyle(VisualElement copyTo, VisualElement copyFrom)
+        {
+            copyTo.style.position = copyFrom.style.position;
+            copyTo.style.top = copyFrom.style.top;
+            copyTo.style.bottom = copyFrom.style.bottom;
+            copyTo.style.left = copyFrom.style.left;
+            copyTo.style.right = copyFrom.style.right;
+            copyTo.style.paddingTop = copyFrom.style.paddingTop;
+            copyTo.style.paddingBottom = copyFrom.style.paddingBottom;
+            copyTo.style.paddingLeft = copyFrom.style.paddingLeft;
+            copyTo.style.paddingRight = copyFrom.style.paddingRight;
+            copyTo.style.alignContent = copyFrom.style.alignContent;
+            copyTo.style.alignItems = copyFrom.style.alignItems;
+            copyTo.style.alignSelf = copyFrom.style.alignSelf;
+            copyTo.style.flexBasis = copyFrom.style.flexBasis;
+            copyTo.style.flexDirection = copyFrom.style.flexDirection;
+            copyTo.style.flexWrap = copyFrom.style.flexWrap;
+            copyTo.style.width = copyFrom.style.width;
+            copyTo.style.height = copyFrom.style.height;
+            copyTo.style.justifyContent = copyFrom.style.justifyContent;
+            copyTo.style.marginTop = copyFrom.style.marginTop;
+            copyTo.style.marginBottom = copyFrom.style.marginBottom;
+            copyTo.style.marginLeft = copyFrom.style.marginLeft;
+            copyTo.style.marginRight = copyFrom.style.marginRight;
+            copyTo.style.transformOrigin = copyFrom.style.transformOrigin;
+            copyTo.style.translate = copyFrom.style.translate;
+            copyTo.style.rotate = copyFrom.style.rotate;
+            copyTo.style.scale = copyFrom.style.scale;
+            copyTo.style.transitionDelay = copyFrom.style.transitionDelay;
+            copyTo.style.transitionDuration = copyFrom.style.transitionDuration;
+            copyTo.style.transitionProperty = copyFrom.style.transitionProperty;
+            copyTo.style.transitionTimingFunction = copyFrom.style.transitionTimingFunction;
+            copyTo.style.color = copyFrom.style.color;
+            copyTo.style.backgroundColor = copyFrom.style.backgroundColor;
+            copyTo.style.unityBackgroundImageTintColor = copyFrom.style.unityBackgroundImageTintColor;
+            copyTo.style.backgroundImage = copyFrom.style.backgroundImage;
+            copyTo.style.backgroundPositionX = copyFrom.style.backgroundPositionX;
+            copyTo.style.backgroundPositionY = copyFrom.style.backgroundPositionY;
+            copyTo.style.backgroundRepeat = copyFrom.style.backgroundRepeat;
+            copyTo.style.backgroundSize = copyFrom.style.backgroundSize;
+            copyTo.style.opacity = copyFrom.style.opacity;
+            copyTo.style.unityOverflowClipBox = copyFrom.style.unityOverflowClipBox;
+            copyTo.style.minWidth = copyFrom.style.minWidth;
+            copyTo.style.maxWidth = copyFrom.style.maxWidth;
+            copyTo.style.minHeight = copyFrom.style.minHeight;
+            copyTo.style.maxHeight = copyFrom.style.maxHeight;
+            copyTo.style.borderTopColor = copyFrom.style.borderTopColor;
+            copyTo.style.borderBottomColor = copyFrom.style.borderBottomColor;
+            copyTo.style.borderLeftColor = copyFrom.style.borderLeftColor;
+            copyTo.style.borderRightColor = copyFrom.style.borderRightColor;
+            copyTo.style.fontSize = copyFrom.style.fontSize;
+            copyTo.style.unityFont = copyFrom.style.unityFont;
+            copyTo.style.unityFontStyleAndWeight = copyFrom.style.unityFontStyleAndWeight;
+            copyTo.style.unityFontDefinition = copyFrom.style.unityFontDefinition;
+            copyTo.style.unityTextAlign = copyFrom.style.unityTextAlign;
+            copyTo.style.textShadow = copyFrom.style.textShadow;
+            copyTo.style.unityTextOutlineColor = copyFrom.style.unityTextOutlineColor;
+            copyTo.style.unityEditorTextRenderingMode = copyFrom.style.unityEditorTextRenderingMode;
+            copyTo.style.unityTextOverflowPosition = copyFrom.style.unityTextOverflowPosition;
+            copyTo.style.textOverflow = copyFrom.style.textOverflow;
+            copyTo.style.unityTextGenerator = copyFrom.style.unityTextGenerator;
+            copyTo.style.unityTextOutlineWidth = copyFrom.style.unityTextOutlineWidth;
+            copyTo.style.wordSpacing = copyFrom.style.wordSpacing;
+            copyTo.style.unityParagraphSpacing = copyFrom.style.unityParagraphSpacing;
+            copyTo.style.whiteSpace = copyFrom.style.whiteSpace;
+            copyTo.style.cursor = copyFrom.style.cursor;
+            copyTo.style.overflow = copyFrom.style.overflow;
+            foreach (var c in copyFrom.GetClasses())
+                copyTo.AddToClassList(c);
+        }
+    }
 }

--- a/Editor/Scripts/Drawers/NumericalAttributeDrawers/UnitFieldDrawer.cs
+++ b/Editor/Scripts/Drawers/NumericalAttributeDrawers/UnitFieldDrawer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using UnityEditor;
 using UnityEditor.UIElements;
@@ -87,137 +88,16 @@ namespace EditorAttributes.Editor
         // that changes values in OnValidate).
         private VisualElement CreateFieldCopy(BindableElement element, SerializedProperty property, UnitFieldAttribute unitFieldAttribute)
         {
+            UnitConverter GetConversion() => UnitConverter.GetConversion(unitFieldAttribute.DisplayUnit, unitFieldAttribute.ConversionUnit);
             UnitConverter convertedUnit = GetConversion();
 
-            if (element is FloatField)
-            {
-                FloatField floatField = element as FloatField;
+            Type fieldType = GetFieldType(element, FieldMask.Numeric);
 
-                var floatFieldCopy = CreateFieldForType<float>(floatField.label, (float)(floatField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as FloatField;
-                floatFieldCopy.RegisterValueChangedCallback((changeEvent) => floatField.value = (float)(floatFieldCopy.value * GetConversion().conversion));
-                //floatField.TrackPropertyValue(property, (property) => floatFieldCopy.SetValueWithoutNotify((float)(floatField.value / GetConversion().conversion)));
-                return floatFieldCopy;
-            }
-            else if (element is DoubleField)
-            {
-                DoubleField doubleField = element as DoubleField;
+            var elementCopy = CreateFieldForType(fieldType, GetFieldLabel(element), Convert.ChangeType(Convert.ToDouble(GetFieldValue(element)) / convertedUnit.conversion, fieldType), property.hasMultipleDifferentValues);
+            RegisterValueChangedCallbackByType(fieldType, elementCopy, (changeEvent) => SetFieldValue(element, Convert.ChangeType(Convert.ToDouble(GetFieldValue(elementCopy)) * GetConversion().conversion, fieldType), true));
+            element.TrackPropertyValue(property, (property) => SetFieldValue(elementCopy, Convert.ChangeType(Convert.ToDouble(GetFieldValue(element)) / GetConversion().conversion, fieldType)));
 
-                var doubleFieldCopy = CreateFieldForType<double>(doubleField.label, doubleField.value / convertedUnit.conversion, property.hasMultipleDifferentValues) as DoubleField;
-                doubleFieldCopy.RegisterValueChangedCallback((changeEvent) => doubleField.value = doubleFieldCopy.value * GetConversion().conversion);
-                //doubleField.TrackPropertyValue(property, (property) => doubleFieldCopy.SetValueWithoutNotify(doubleField.value / GetConversion().conversion));
-                return doubleFieldCopy;
-            }
-            else if (element is IntegerField)
-            {
-                IntegerField integerField = element as IntegerField;
-
-                var integerFieldCopy = CreateFieldForType<int>(integerField.label, (int)(integerField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as IntegerField;
-                integerFieldCopy.RegisterValueChangedCallback((changeEvent) => integerField.value = (int)(integerFieldCopy.value * GetConversion().conversion));
-                //integerField.TrackPropertyValue(property, (property) => integerFieldCopy.SetValueWithoutNotify((int)(integerField.value / GetConversion().conversion)));
-                return integerFieldCopy;
-            }
-            else if (element is UnsignedIntegerField)
-            {
-                UnsignedIntegerField unsignedIntegerField = element as UnsignedIntegerField;
-
-                var unsignedIntegerFieldCopy = CreateFieldForType<uint>(unsignedIntegerField.label, (uint)(unsignedIntegerField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as UnsignedIntegerField;
-                unsignedIntegerFieldCopy.RegisterValueChangedCallback((changeEvent) => unsignedIntegerField.value = (uint)(unsignedIntegerFieldCopy.value * GetConversion().conversion));
-                //unsignedIntegerField.TrackPropertyValue(property, (property) => unsignedIntegerFieldCopy.SetValueWithoutNotify((uint)(unsignedIntegerField.value / GetConversion().conversion)));
-                return unsignedIntegerFieldCopy;
-            }
-            else if (element is LongField)
-            {
-                LongField longField = element as LongField;
-
-                var longFieldCopy = CreateFieldForType<long>(longField.label, (long)(longField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as LongField;
-                longFieldCopy.RegisterValueChangedCallback((changeEvent) => longField.value = (long)(longFieldCopy.value * GetConversion().conversion));
-                //longField.TrackPropertyValue(property, (property) => longFieldCopy.SetValueWithoutNotify((long)(longField.value / GetConversion().conversion)));
-                return longFieldCopy;
-            }
-            else if (element is UnsignedLongField)
-            {
-                UnsignedLongField unsignedLongField = element as UnsignedLongField;
-
-                var unsignedLongFieldCopy = CreateFieldForType<ulong>(unsignedLongField.label, (ulong)(unsignedLongField.value / convertedUnit.conversion), property.hasMultipleDifferentValues) as UnsignedLongField;
-                unsignedLongFieldCopy.RegisterValueChangedCallback((changeEvent) => unsignedLongField.value = (ulong)(unsignedLongFieldCopy.value * GetConversion().conversion));
-                //unsignedLongField.TrackPropertyValue(property, (property) => unsignedLongFieldCopy.SetValueWithoutNotify((ulong)(unsignedLongField.value / GetConversion().conversion)));
-                return unsignedLongFieldCopy;
-            }
-            else
-                return null;
-
-            UnitConverter GetConversion() => UnitConverter.GetConversion(unitFieldAttribute.DisplayUnit, unitFieldAttribute.ConversionUnit);
-        }
-
-        private void CopyStyle(VisualElement copyTo, VisualElement copyFrom)
-        {
-            copyTo.style.position = copyFrom.style.position;
-            copyTo.style.top = copyFrom.style.top;
-            copyTo.style.bottom = copyFrom.style.bottom;
-            copyTo.style.left = copyFrom.style.left;
-            copyTo.style.right = copyFrom.style.right;
-            copyTo.style.paddingTop = copyFrom.style.paddingTop;
-            copyTo.style.paddingBottom = copyFrom.style.paddingBottom;
-            copyTo.style.paddingLeft = copyFrom.style.paddingLeft;
-            copyTo.style.paddingRight = copyFrom.style.paddingRight;
-            copyTo.style.alignContent = copyFrom.style.alignContent;
-            copyTo.style.alignItems = copyFrom.style.alignItems;
-            copyTo.style.alignSelf = copyFrom.style.alignSelf;
-            copyTo.style.flexBasis = copyFrom.style.flexBasis;
-            copyTo.style.flexDirection = copyFrom.style.flexDirection;
-            copyTo.style.flexWrap = copyFrom.style.flexWrap;
-            copyTo.style.width = copyFrom.style.width;
-            copyTo.style.height = copyFrom.style.height;
-            copyTo.style.justifyContent = copyFrom.style.justifyContent;
-            copyTo.style.marginTop = copyFrom.style.marginTop;
-            copyTo.style.marginBottom = copyFrom.style.marginBottom;
-            copyTo.style.marginLeft = copyFrom.style.marginLeft;
-            copyTo.style.marginRight = copyFrom.style.marginRight;
-            copyTo.style.transformOrigin = copyFrom.style.transformOrigin;
-            copyTo.style.translate = copyFrom.style.translate;
-            copyTo.style.rotate = copyFrom.style.rotate;
-            copyTo.style.scale = copyFrom.style.scale;
-            copyTo.style.transitionDelay = copyFrom.style.transitionDelay;
-            copyTo.style.transitionDuration = copyFrom.style.transitionDuration;
-            copyTo.style.transitionProperty = copyFrom.style.transitionProperty;
-            copyTo.style.transitionTimingFunction = copyFrom.style.transitionTimingFunction;
-            copyTo.style.color = copyFrom.style.color;
-            copyTo.style.backgroundColor = copyFrom.style.backgroundColor;
-            copyTo.style.unityBackgroundImageTintColor = copyFrom.style.unityBackgroundImageTintColor;
-            copyTo.style.backgroundImage = copyFrom.style.backgroundImage;
-            copyTo.style.backgroundPositionX = copyFrom.style.backgroundPositionX;
-            copyTo.style.backgroundPositionY = copyFrom.style.backgroundPositionY;
-            copyTo.style.backgroundRepeat = copyFrom.style.backgroundRepeat;
-            copyTo.style.backgroundSize = copyFrom.style.backgroundSize;
-            copyTo.style.opacity = copyFrom.style.opacity;
-            copyTo.style.unityOverflowClipBox = copyFrom.style.unityOverflowClipBox;
-            copyTo.style.minWidth = copyFrom.style.minWidth;
-            copyTo.style.maxWidth = copyFrom.style.maxWidth;
-            copyTo.style.minHeight = copyFrom.style.minHeight;
-            copyTo.style.maxHeight = copyFrom.style.maxHeight;
-            copyTo.style.borderTopColor = copyFrom.style.borderTopColor;
-            copyTo.style.borderBottomColor = copyFrom.style.borderBottomColor;
-            copyTo.style.borderLeftColor = copyFrom.style.borderLeftColor;
-            copyTo.style.borderRightColor = copyFrom.style.borderRightColor;
-            copyTo.style.fontSize = copyFrom.style.fontSize;
-            copyTo.style.unityFont = copyFrom.style.unityFont;
-            copyTo.style.unityFontStyleAndWeight = copyFrom.style.unityFontStyleAndWeight;
-            copyTo.style.unityFontDefinition = copyFrom.style.unityFontDefinition;
-            copyTo.style.unityTextAlign = copyFrom.style.unityTextAlign;
-            copyTo.style.textShadow = copyFrom.style.textShadow;
-            copyTo.style.unityTextOutlineColor = copyFrom.style.unityTextOutlineColor;
-            copyTo.style.unityEditorTextRenderingMode = copyFrom.style.unityEditorTextRenderingMode;
-            copyTo.style.unityTextOverflowPosition = copyFrom.style.unityTextOverflowPosition;
-            copyTo.style.textOverflow = copyFrom.style.textOverflow;
-            copyTo.style.unityTextGenerator = copyFrom.style.unityTextGenerator;
-            copyTo.style.unityTextOutlineWidth = copyFrom.style.unityTextOutlineWidth;
-            copyTo.style.wordSpacing = copyFrom.style.wordSpacing;
-            copyTo.style.unityParagraphSpacing = copyFrom.style.unityParagraphSpacing;
-            copyTo.style.whiteSpace = copyFrom.style.whiteSpace;
-            copyTo.style.cursor = copyFrom.style.cursor;
-            copyTo.style.overflow = copyFrom.style.overflow;
-            foreach (var c in copyFrom.GetClasses())
-                copyTo.AddToClassList(c);
+            return elementCopy;
         }
     }
 }

--- a/Editor/Scripts/Drawers/PropertyDrawerBase.cs
+++ b/Editor/Scripts/Drawers/PropertyDrawerBase.cs
@@ -540,15 +540,137 @@ namespace EditorAttributes.Editor
 			visualElement.style.marginLeft = 3f;
 		}
 
-		/// <summary>
-		/// Creates a field for a specific type
-		/// </summary>
-		/// <typeparam name="T"> The type of the field to create</typeparam>
-		/// <param name="fieldName">The name of the field</param>
-		/// <param name="fieldValue">The default value of the field</param>
-		/// <param name="showMixedValue">Whether to show the mixed value state for the field</param>
-		/// <returns>A visual element of the appropriate field</returns>
-		public static VisualElement CreateFieldForType<T>(string fieldName, object fieldValue, bool showMixedValue = false) => CreateFieldForType(typeof(T), fieldName, fieldValue, showMixedValue);
+        /// <summary>
+        /// Copies all of the style values from a <see cref="VisualElement"/> to another
+        /// </summary>
+        /// <param name="copyTo">The element to copy the style to</param>
+        /// <param name="copyFrom">The element to copy the style from</param>
+        public void CopyStyle(VisualElement copyTo, VisualElement copyFrom)
+        {
+            copyTo.style.position = copyFrom.style.position;
+            copyTo.style.top = copyFrom.style.top;
+            copyTo.style.bottom = copyFrom.style.bottom;
+            copyTo.style.left = copyFrom.style.left;
+            copyTo.style.right = copyFrom.style.right;
+            copyTo.style.paddingTop = copyFrom.style.paddingTop;
+            copyTo.style.paddingBottom = copyFrom.style.paddingBottom;
+            copyTo.style.paddingLeft = copyFrom.style.paddingLeft;
+            copyTo.style.paddingRight = copyFrom.style.paddingRight;
+            copyTo.style.alignContent = copyFrom.style.alignContent;
+            copyTo.style.alignItems = copyFrom.style.alignItems;
+            copyTo.style.alignSelf = copyFrom.style.alignSelf;
+            copyTo.style.flexBasis = copyFrom.style.flexBasis;
+            copyTo.style.flexDirection = copyFrom.style.flexDirection;
+            copyTo.style.flexWrap = copyFrom.style.flexWrap;
+            copyTo.style.width = copyFrom.style.width;
+            copyTo.style.height = copyFrom.style.height;
+            copyTo.style.justifyContent = copyFrom.style.justifyContent;
+            copyTo.style.marginTop = copyFrom.style.marginTop;
+            copyTo.style.marginBottom = copyFrom.style.marginBottom;
+            copyTo.style.marginLeft = copyFrom.style.marginLeft;
+            copyTo.style.marginRight = copyFrom.style.marginRight;
+            copyTo.style.transformOrigin = copyFrom.style.transformOrigin;
+            copyTo.style.translate = copyFrom.style.translate;
+            copyTo.style.rotate = copyFrom.style.rotate;
+            copyTo.style.scale = copyFrom.style.scale;
+            copyTo.style.transitionDelay = copyFrom.style.transitionDelay;
+            copyTo.style.transitionDuration = copyFrom.style.transitionDuration;
+            copyTo.style.transitionProperty = copyFrom.style.transitionProperty;
+            copyTo.style.transitionTimingFunction = copyFrom.style.transitionTimingFunction;
+            copyTo.style.color = copyFrom.style.color;
+            copyTo.style.backgroundColor = copyFrom.style.backgroundColor;
+            copyTo.style.unityBackgroundImageTintColor = copyFrom.style.unityBackgroundImageTintColor;
+            copyTo.style.backgroundImage = copyFrom.style.backgroundImage;
+            copyTo.style.backgroundPositionX = copyFrom.style.backgroundPositionX;
+            copyTo.style.backgroundPositionY = copyFrom.style.backgroundPositionY;
+            copyTo.style.backgroundRepeat = copyFrom.style.backgroundRepeat;
+            copyTo.style.backgroundSize = copyFrom.style.backgroundSize;
+            copyTo.style.opacity = copyFrom.style.opacity;
+            copyTo.style.unityOverflowClipBox = copyFrom.style.unityOverflowClipBox;
+            copyTo.style.minWidth = copyFrom.style.minWidth;
+            copyTo.style.maxWidth = copyFrom.style.maxWidth;
+            copyTo.style.minHeight = copyFrom.style.minHeight;
+            copyTo.style.maxHeight = copyFrom.style.maxHeight;
+            copyTo.style.borderTopColor = copyFrom.style.borderTopColor;
+            copyTo.style.borderBottomColor = copyFrom.style.borderBottomColor;
+            copyTo.style.borderLeftColor = copyFrom.style.borderLeftColor;
+            copyTo.style.borderRightColor = copyFrom.style.borderRightColor;
+            copyTo.style.fontSize = copyFrom.style.fontSize;
+            copyTo.style.unityFont = copyFrom.style.unityFont;
+            copyTo.style.unityFontStyleAndWeight = copyFrom.style.unityFontStyleAndWeight;
+            copyTo.style.unityFontDefinition = copyFrom.style.unityFontDefinition;
+            copyTo.style.unityTextAlign = copyFrom.style.unityTextAlign;
+            copyTo.style.textShadow = copyFrom.style.textShadow;
+            copyTo.style.unityTextOutlineColor = copyFrom.style.unityTextOutlineColor;
+            copyTo.style.unityEditorTextRenderingMode = copyFrom.style.unityEditorTextRenderingMode;
+            copyTo.style.unityTextOverflowPosition = copyFrom.style.unityTextOverflowPosition;
+            copyTo.style.textOverflow = copyFrom.style.textOverflow;
+            copyTo.style.unityTextGenerator = copyFrom.style.unityTextGenerator;
+            copyTo.style.unityTextOutlineWidth = copyFrom.style.unityTextOutlineWidth;
+            copyTo.style.wordSpacing = copyFrom.style.wordSpacing;
+            copyTo.style.unityParagraphSpacing = copyFrom.style.unityParagraphSpacing;
+            copyTo.style.whiteSpace = copyFrom.style.whiteSpace;
+            copyTo.style.cursor = copyFrom.style.cursor;
+            copyTo.style.overflow = copyFrom.style.overflow;
+            foreach (var c in copyFrom.GetClasses())
+                copyTo.AddToClassList(c);
+        }
+
+        /// <summary>
+        /// Returns the type of the field
+        /// </summary>
+        /// <param name="field">The visual element of the field</param>
+        /// <param name="mask">Restrict the returned field type to specific </param>
+        /// <returns>The type of the field</returns>
+        public Type GetFieldType(VisualElement field, FieldMask mask = FieldMask.Any) => field switch
+        {
+            IntegerField => (mask & FieldMask.Numeric) != 0 ? typeof(int) : null,
+            UnsignedIntegerField => (mask & FieldMask.Numeric) != 0 ? typeof(uint) : null,
+            LongField => (mask & FieldMask.Numeric) != 0 ? typeof(long) : null,
+            UnsignedLongField => (mask & FieldMask.Numeric) != 0 ? typeof(ulong) : null,
+            FloatField => (mask & FieldMask.Numeric) != 0 ? typeof(float) : null,
+            DoubleField => (mask & FieldMask.Numeric) != 0 ? typeof(double) : null,
+            Toggle => (mask & FieldMask.Bool) != 0 ? typeof(bool) : null,
+            TextField => (mask & FieldMask.String) != 0 ? typeof(string) : null,
+            ColorField => (mask & FieldMask.Color) != 0 ? typeof(Color) : null,
+            GradientField => (mask & FieldMask.Color) != 0 ? typeof(Gradient) : null,
+            EnumField => (mask & FieldMask.Enum) != 0 ? typeof(Enum) : null,
+            LayerMaskField => (mask & FieldMask.Enum) != 0 ? typeof(LayerMask) : null,
+            CurveField => (mask & FieldMask.Animation) != 0 ? typeof(AnimationCurve) : null,
+            Vector2Field => (mask & FieldMask.Composite) != 0 ? typeof(Vector2) : null,
+            Vector2IntField => (mask & FieldMask.Composite) != 0 ? typeof(Vector2Int) : null,
+            Vector3Field => (mask & FieldMask.Composite) != 0 ? typeof(Vector3) : null,
+            Vector3IntField => (mask & FieldMask.Composite) != 0 ? typeof(Vector3Int) : null,
+            Vector4Field => (mask & FieldMask.Composite) != 0 ? typeof(Vector4) : null,
+            RectField => (mask & FieldMask.Composite) != 0 ? typeof(Rect) : null,
+            RectIntField => (mask & FieldMask.Composite) != 0 ? typeof(RectInt) : null,
+            BoundsField => (mask & FieldMask.Composite) != 0 ? typeof(Bounds) : null,
+            BoundsIntField => (mask & FieldMask.Composite) != 0 ? typeof(BoundsInt) : null,
+            _ => null
+        };
+
+        [Flags]
+        public enum FieldMask
+        {
+            Any = ~0,
+            Bool = 1 << 0,
+            Numeric = 1 << 1,
+            String = 1 << 2,
+            Color = 1 << 3,
+            Enum = 1 << 4,
+            Animation = 1 << 5,
+            Composite = 1 << 6,
+        }
+
+        /// <summary>
+        /// Creates a field for a specific type
+        /// </summary>
+        /// <typeparam name="T"> The type of the field to create</typeparam>
+        /// <param name="fieldName">The name of the field</param>
+        /// <param name="fieldValue">The default value of the field</param>
+        /// <param name="showMixedValue">Whether to show the mixed value state for the field</param>
+        /// <returns>A visual element of the appropriate field</returns>
+        public static VisualElement CreateFieldForType<T>(string fieldName, object fieldValue, bool showMixedValue = false) => CreateFieldForType(typeof(T), fieldName, fieldValue, showMixedValue);
 
 		/// <summary>
 		/// Creates a field for a specific type
@@ -794,13 +916,45 @@ namespace EditorAttributes.Editor
 			_ => null,
 		};
 
-		/// <summary>
-		/// Sets the value of the appropriate field
-		/// </summary>
-		/// <param name="field">The visual element of the field</param>
-		/// <param name="value">The value to set</param>
-		/// <param name="notify">Whether to call the value change callback when setting the value</param>
-		public static void SetFieldValue(VisualElement field, object value, bool notify = false)
+        /// <summary>
+        /// Gets the label of the appropriate field
+        /// </summary>
+        /// <param name="field">The visual element of the field</param>
+        /// <returns>The field label</returns>
+        public static string GetFieldLabel(VisualElement field) => field switch
+        {
+            TextField textField => textField.label,
+            IntegerField integerField => integerField.label,
+            UnsignedIntegerField unsignedIntegerField => unsignedIntegerField.label,
+            LongField longField => longField.label,
+            UnsignedLongField unsignedLongField => unsignedLongField.label,
+            FloatField floatField => floatField.label,
+            DoubleField doubleField => doubleField.label,
+            Toggle toggle => toggle.label,
+            EnumField enumField => enumField.label,
+            Vector2Field vector2Field => vector2Field.label,
+            Vector2IntField vector2IntField => vector2IntField.label,
+            Vector3Field vector3Field => vector3Field.label,
+            Vector3IntField vector3IntField => vector3IntField.label,
+            Vector4Field vector4Field => vector4Field.label,
+            ColorField colorField => colorField.label,
+            GradientField gradientField => gradientField.label,
+            CurveField curveField => curveField.label,
+            LayerMaskField layerMaskField => layerMaskField.label,
+            RectField rectField => rectField.label,
+            RectIntField rectIntField => rectIntField.label,
+            BoundsField boundsField => boundsField.label,
+            BoundsIntField boundsIntField => boundsIntField.label,
+            _ => null,
+        };
+
+        /// <summary>
+        /// Sets the value of the appropriate field
+        /// </summary>
+        /// <param name="field">The visual element of the field</param>
+        /// <param name="value">The value to set</param>
+        /// <param name="notify">Whether to call the value change callback when setting the value</param>
+        public static void SetFieldValue(VisualElement field, object value, bool notify = false)
 		{
 			if (field is TextField textField)
 			{

--- a/Editor/Scripts/EditorAttributesSettings.cs
+++ b/Editor/Scripts/EditorAttributesSettings.cs
@@ -58,7 +58,7 @@ namespace EditorAttributes.Editor
 
 			var helpButton = new Button(() => Application.OpenURL("https://editorattributesdocs.readthedocs.io/en/latest/GettingStarted/editorattributessettings.html"))
 			{
-				tooltip = "Open reference for EditorAttributes Settings.",
+				tooltip = "Open reference for Editor Attributes Settings.",
 				style =
 				{
 					borderTopLeftRadius = 0f, borderTopRightRadius = 0f, borderBottomLeftRadius = 0f, borderBottomRightRadius = 0f,
@@ -88,7 +88,7 @@ namespace EditorAttributes.Editor
 			var clearParamsButton = new Button(() => ButtonDrawer.ClearAllParamsData())
 			{
 				text = "Delete Buttons Parameter Data",
-				tooltip = "Deletes all buttons parameter data stored in ProjectSettings/EditorAttributes",
+				tooltip = "Deletes all buttons parameter data stored in Project Settings/Editor Attributes",
 				style = { marginTop = 10f }
 			};
 
@@ -105,7 +105,7 @@ namespace EditorAttributes.Editor
 		public override void OnDeactivate() => EditorAttributesSettings.instance.SaveSettings();
 
 		[SettingsProvider]
-		internal static SettingsProvider CreateSettingsProvider() => new EditorAttributesSettingsProvider("Project/EditorAttributes", SettingsScope.Project)
+		internal static SettingsProvider CreateSettingsProvider() => new EditorAttributesSettingsProvider("Project/Editor Attributes", SettingsScope.Project)
 		{
 			keywords = new HashSet<string>(new[] { "EditorAttributes", "Editor", "Attributes" })
 		};

--- a/Editor/Scripts/EditorAttributesSettings.cs
+++ b/Editor/Scripts/EditorAttributesSettings.cs
@@ -17,17 +17,20 @@ namespace EditorAttributes.Editor
 
 		internal void AddCustomDefinitions()
 		{
-			foreach (var customUnitDefinition in customUnitDefinitions)
-			{
-				if (customUnitDefinition.category != UnitCategory.Custom)
-					customUnitDefinition.categoryName = customUnitDefinition.category.ToString();
-			}
+            var unitDefinitions = UnitConverter.UNIT_DEFINITIONS;
 
-			var unitDefinitions = UnitConverter.UNIT_DEFINITIONS;
+            unitDefinitions.RemoveWhere((unitDefinition) => unitDefinition.unit == Unit.Custom);
 
-			unitDefinitions.RemoveWhere((unitDefinition) => unitDefinition.unit == Unit.Custom);
-			unitDefinitions.UnionWith(customUnitDefinitions);
-		}
+            if (customUnitDefinitions == null)
+                return;
+
+            foreach (var customUnitDefinition in customUnitDefinitions)
+            {
+                if (customUnitDefinition.category != UnitCategory.Custom)
+                    customUnitDefinition.categoryName = customUnitDefinition.category.ToString();
+            }
+            unitDefinitions.UnionWith(customUnitDefinitions);
+        }
 
 		internal void SaveSettings() => Save(true);
 	}

--- a/Editor/Scripts/EditorAttributesSettings.cs
+++ b/Editor/Scripts/EditorAttributesSettings.cs
@@ -58,7 +58,7 @@ namespace EditorAttributes.Editor
 
 			var helpButton = new Button(() => Application.OpenURL("https://editorattributesdocs.readthedocs.io/en/latest/GettingStarted/editorattributessettings.html"))
 			{
-				tooltip = "Open reference for Editor Attributes Settings.",
+				tooltip = "Open reference for EditorAttributes Settings.",
 				style =
 				{
 					borderTopLeftRadius = 0f, borderTopRightRadius = 0f, borderBottomLeftRadius = 0f, borderBottomRightRadius = 0f,
@@ -88,7 +88,7 @@ namespace EditorAttributes.Editor
 			var clearParamsButton = new Button(() => ButtonDrawer.ClearAllParamsData())
 			{
 				text = "Delete Buttons Parameter Data",
-				tooltip = "Deletes all buttons parameter data stored in Project Settings/Editor Attributes",
+				tooltip = "Deletes all buttons parameter data stored in ProjectSettings/EditorAttributes",
 				style = { marginTop = 10f }
 			};
 
@@ -105,7 +105,7 @@ namespace EditorAttributes.Editor
 		public override void OnDeactivate() => EditorAttributesSettings.instance.SaveSettings();
 
 		[SettingsProvider]
-		internal static SettingsProvider CreateSettingsProvider() => new EditorAttributesSettingsProvider("Project/Editor Attributes", SettingsScope.Project)
+		internal static SettingsProvider CreateSettingsProvider() => new EditorAttributesSettingsProvider("Project/EditorAttributes", SettingsScope.Project)
 		{
 			keywords = new HashSet<string>(new[] { "EditorAttributes", "Editor", "Attributes" })
 		};

--- a/Editor/Scripts/UnitConverter.cs
+++ b/Editor/Scripts/UnitConverter.cs
@@ -28,8 +28,9 @@ namespace EditorAttributes.Editor
 		Frequency,
 		Data,
 		Density,
-		FuelEconomy
-	}
+		FuelEconomy,
+        Percent
+    }
 
 	[Serializable]
 	internal class UnitDefinition
@@ -316,7 +317,13 @@ namespace EditorAttributes.Editor
 			new(Unit.MilesPerGallon_US, "mpg", UnitCategory.FuelEconomy, 1d),
 			new(Unit.MilesPerGallon_UK, "mpg", UnitCategory.FuelEconomy, 1.20095d),
 			new(Unit.LitersPer100Kilometers, "L/100km", UnitCategory.FuelEconomy, 235.215d),
-		};
+
+			// Percent (base: %m)
+			new(Unit.PercentMultiplier, "%m", UnitCategory.Percent, 1d),
+            new(Unit.Percent, "%", UnitCategory.Percent, 0.01d),
+            new(Unit.Permille, "‰", UnitCategory.Percent, 0.001d),
+            new(Unit.Permyriad, "‱", UnitCategory.Percent, 0.0001d),
+        };
 
 		internal static Dictionary<(string from, string to), UnitConverter> UNIT_CONVERSION_MAP = new();
 

--- a/Editor/Scripts/UnitConverter.cs
+++ b/Editor/Scripts/UnitConverter.cs
@@ -29,7 +29,7 @@ namespace EditorAttributes.Editor
 		Data,
 		Density,
 		FuelEconomy,
-        Percent
+        Percentage
     }
 
 	[Serializable]
@@ -319,10 +319,10 @@ namespace EditorAttributes.Editor
 			new(Unit.LitersPer100Kilometers, "L/100km", UnitCategory.FuelEconomy, 235.215d),
 
 			// Percent (base: %m)
-			new(Unit.PercentMultiplier, "%m", UnitCategory.Percent, 1d),
-            new(Unit.Percent, "%", UnitCategory.Percent, 0.01d),
-            new(Unit.Permille, "‰", UnitCategory.Percent, 0.001d),
-            new(Unit.Permyriad, "‱", UnitCategory.Percent, 0.0001d),
+			new(Unit.PercentMultiplier, "%m", UnitCategory.Percentage, 1d),
+            new(Unit.Percent, "%", UnitCategory.Percentage, 0.01d),
+            new(Unit.Permille, "‰", UnitCategory.Percentage, 0.001d),
+            new(Unit.Permyriad, "‱", UnitCategory.Percentage, 0.0001d),
         };
 
 		internal static Dictionary<(string from, string to), UnitConverter> UNIT_CONVERSION_MAP = new();

--- a/Runtime/Scripts/Attributes/NumericalAttributes/UnitFieldAttribute.cs
+++ b/Runtime/Scripts/Attributes/NumericalAttributes/UnitFieldAttribute.cs
@@ -10,12 +10,32 @@ namespace EditorAttributes
 		public string DisplayUnit { get; private set; }
 		public string ConversionUnit { get; private set; }
 
-		/// <summary>
-		/// Attribute to display a numerical field as a specified unit and convert it to another unit
-		/// </summary>
-		/// <param name="displayUnit">The unit to display in the inspector</param>
-		/// <param name="conversionUnit">The unit to convert to</param>
-		public UnitFieldAttribute(Unit displayUnit, Unit conversionUnit)
+        /// <summary>
+        /// Attribute to display a numerical field as a specified unit
+        /// </summary>
+        /// <param name="displayUnit">The unit to display in the inspector</param>
+        public UnitFieldAttribute(Unit displayUnit)
+        {
+            DisplayUnit = displayUnit.ToString();
+            ConversionUnit = displayUnit.ToString();
+        }
+
+        /// <summary>
+        /// Attribute to display a numerical field as a specified unit
+        /// </summary>
+        /// <param name="customDisplayUnit">The custom unit to display in the inspector</param>
+        public UnitFieldAttribute(string customDisplayUnit)
+        {
+            DisplayUnit = customDisplayUnit;
+            ConversionUnit = customDisplayUnit;
+        }
+
+        /// <summary>
+        /// Attribute to display a numerical field as a specified unit and convert it to another unit
+        /// </summary>
+        /// <param name="displayUnit">The unit to display in the inspector</param>
+        /// <param name="conversionUnit">The unit to convert to</param>
+        public UnitFieldAttribute(Unit displayUnit, Unit conversionUnit)
 		{
 			DisplayUnit = displayUnit.ToString();
 			ConversionUnit = conversionUnit.ToString();

--- a/Runtime/Scripts/Attributes/NumericalAttributes/UnitFieldAttribute.cs
+++ b/Runtime/Scripts/Attributes/NumericalAttributes/UnitFieldAttribute.cs
@@ -11,26 +11,6 @@ namespace EditorAttributes
 		public string ConversionUnit { get; private set; }
 
         /// <summary>
-        /// Attribute to display a numerical field as a specified unit
-        /// </summary>
-        /// <param name="displayUnit">The unit to display in the inspector</param>
-        public UnitFieldAttribute(Unit displayUnit)
-        {
-            DisplayUnit = displayUnit.ToString();
-            ConversionUnit = displayUnit.ToString();
-        }
-
-        /// <summary>
-        /// Attribute to display a numerical field as a specified unit
-        /// </summary>
-        /// <param name="customDisplayUnit">The custom unit to display in the inspector</param>
-        public UnitFieldAttribute(string customDisplayUnit)
-        {
-            DisplayUnit = customDisplayUnit;
-            ConversionUnit = customDisplayUnit;
-        }
-
-        /// <summary>
         /// Attribute to display a numerical field as a specified unit and convert it to another unit
         /// </summary>
         /// <param name="displayUnit">The unit to display in the inspector</param>

--- a/Runtime/Scripts/DataTypes/Unit.cs
+++ b/Runtime/Scripts/DataTypes/Unit.cs
@@ -256,5 +256,11 @@ namespace EditorAttributes
 		MilesPerGallon_US,
 		MilesPerGallon_UK,
 		LitersPer100Kilometers,
-	}
+
+        // Percent
+        PercentMultiplier,
+        Percent,
+        Permille,
+        Permyriad,
+    }
 }


### PR DESCRIPTION
Full Changelist:
- Fix to missing object reference error in settings when trying to use the UnitField in a fresh project
- Correctly colors the field when using the [Color] attribute
- Updates visual value when the property value is changed by script
- Now works with any type (even custom) that implements Visual Elements and has numerical fields
- Adjusted unit display to align with text
- Added percent units to the Unit Converter
- Added non-conversion UnitField constructor (for if you just want unit display and no conversion)