### PR TITLE
Fix null reference in addressables validation during build

### DIFF
--- a/Editor/Scripts/EditorValidation.cs
+++ b/Editor/Scripts/EditorValidation.cs
@@ -83,6 +83,9 @@ namespace EditorAttributes.Editor
 #if HAS_ADDRESSABLES_PACKAGE
 			var settings = AddressableAssetSettingsDefaultObject.Settings;
 
+			if (settings == null)
+				return false;
+			
 			foreach (var group in settings.groups)
 			{
 				if (group == null || group.entries.Count == 0)


### PR DESCRIPTION
Added a null check for `AddressableAssetSettingsDefaultObject.Settings` to prevent a potential `NullReferenceException` during validation if `Addressables` package is installed, but not used.