### PR TITLE
Allow attributes to find private members of parent classes

### DIFF
--- a/Editor/Scripts/EditorExtension.cs
+++ b/Editor/Scripts/EditorExtension.cs
@@ -27,7 +27,15 @@ namespace EditorAttributes.Editor
 
 		protected virtual void OnEnable()
 		{
-			functions = target.GetType().GetMethods(ReflectionUtility.BINDING_FLAGS);
+            var funcList = new List<MethodInfo>();
+            var targetType = target.GetType();
+            while (targetType != null)
+            {
+                funcList.AddRange(targetType.GetMethods(ReflectionUtility.BINDING_FLAGS));
+                targetType = targetType.BaseType;
+            }
+
+			functions = funcList.ToArray();
 
 			ButtonDrawer.LoadParamsData(functions, target, ref buttonFoldouts, ref buttonParameterValues);
 
@@ -59,7 +67,7 @@ namespace EditorAttributes.Editor
 
 			var root = new VisualElement();
 
-			var nonSerializedMembers = DrawNonSerilizedMembers();
+			var nonSerializedMembers = DrawNonSerializedMembers();
 			var defaultInspector = DrawDefaultInspector();
 			var buttons = DrawButtons();
 
@@ -140,7 +148,7 @@ namespace EditorAttributes.Editor
 		/// Draws all the members marked with the ShowInInspector attribute
 		/// </summary>
 		/// <returns>A visual element containing all non serialized member fields</returns>
-		protected VisualElement DrawNonSerilizedMembers()
+		protected VisualElement DrawNonSerializedMembers()
 		{
 			var root = new VisualElement();
 

--- a/Editor/Scripts/Utilities/ReflectionUtility.cs
+++ b/Editor/Scripts/Utilities/ReflectionUtility.cs
@@ -137,29 +137,33 @@ namespace EditorAttributes.Editor.Utility
 		/// <returns>The member info of the specified member type</returns>
 		public static MemberInfo FindMember(string memberName, Type targetType, BindingFlags bindingFlags, MemberTypes memberType)
 		{
-			switch (memberType)
-			{
-				case MemberTypes.Field:
-				{
-					if (targetType != null)
-						return targetType.GetField(memberName, bindingFlags);
-				}
-				break;
+            MemberInfo memberInfo = null;
+            while (targetType != null)
+            {
+                switch (memberType)
+                {
+                    case MemberTypes.Field:
+                        {
+                            memberInfo = targetType.GetField(memberName, bindingFlags);
+                        }
+                        break;
 
-				case MemberTypes.Property:
-				{
-					if (targetType != null)
-						return targetType.GetProperty(memberName, bindingFlags);
-				}
-				break;
+                    case MemberTypes.Property:
+                        {
+                            memberInfo = targetType.GetProperty(memberName, bindingFlags);
+                        }
+                        break;
 
-				case MemberTypes.Method:
-				{
-					if (targetType != null)
-						return targetType.GetMethod(memberName, bindingFlags);
-				}
-				break;
-			}
+                    case MemberTypes.Method:
+                        {
+                            memberInfo = targetType.GetMethod(memberName, bindingFlags);
+                        }
+                        break;
+                }
+
+                if (memberInfo != null) return memberInfo;
+                targetType = targetType.BaseType;
+            }
 
 			return null;
 		}


### PR DESCRIPTION
Button attribute and other attributes with dynamic string option (HelpBox, Validate) will not be applied if the target member is private inside a parent class. This PR fixes that and while hopefully not breaking anything.

```
public abstract class Foo : MonoBehaviour
{
    [Button]
    private void Bar() { }
}
```