### PR TITLE
Add RequiresConstantRepaintAttribute

### DIFF
--- a/Editor/Scripts/EditorExtension.cs
+++ b/Editor/Scripts/EditorExtension.cs
@@ -25,6 +25,8 @@ namespace EditorAttributes.Editor
 
         private MethodInfo[] functions;
 
+        private bool requiresConstantRepaint = false;
+
         protected virtual void OnEnable()
         {
             List<MethodInfo> functionList = new();
@@ -39,6 +41,8 @@ namespace EditorAttributes.Editor
                     if (!functionList.Contains(methodInfo))
                         functionList.Add(methodInfo);
                 }
+
+                requiresConstantRepaint |= targetType.GetCustomAttribute<RequiresConstantRepaintAttribute>() != null;
 
                 targetType = targetType.BaseType;
             }
@@ -65,6 +69,8 @@ namespace EditorAttributes.Editor
             EditorHandles.handleProperties.Clear();
             EditorHandles.boundsHandleList.Clear();
         }
+
+        public override bool RequiresConstantRepaint() => requiresConstantRepaint;
 
         void OnSceneGUI() => EditorHandles.DrawHandles();
 

--- a/Runtime/Scripts/Attributes/MiscellaneousAttributes/RequiresConstantRepaintAttribute.cs
+++ b/Runtime/Scripts/Attributes/MiscellaneousAttributes/RequiresConstantRepaintAttribute.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace EditorAttributes
+{
+    /// <summary>
+    /// Attribute to mark an Editor as requiring constant repainting in the inspector
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public class RequiresConstantRepaintAttribute : Attribute
+    {
+        /// <summary>
+        /// Attribute to mark an Editor as requiring constant repainting in the inspector
+        /// </summary>
+        public RequiresConstantRepaintAttribute() { }
+    }
+}

--- a/Runtime/Scripts/Attributes/MiscellaneousAttributes/RequiresConstantRepaintAttribute.cs.meta
+++ b/Runtime/Scripts/Attributes/MiscellaneousAttributes/RequiresConstantRepaintAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d0bfce06734449709c4f8c3061435706
+timeCreated: 1771338618


### PR DESCRIPTION
Particularly for inspectors with custom PropertyDrawers, it can be very annoying to force the inspectors to repaint without making a wrapper CustomEditor for every such component. The Unity forums have several threads on this, and most of the workarounds boil down to "find every active editor on every frame using an internal API and redraw all of them".

This attribute essentially just parameterizes `EditorExtension` so we can tell it to return `true` from `public virtual bool Editor.RequiresConstantRepaint()` without having to subclass a custom editor for this sole purpose.