### PR TITLE
Added ability to hide ProgressBar text

### DIFF
--- a/Editor/Scripts/Drawers/NumericalAttributeDrawers/ProgressBarDrawer.cs
+++ b/Editor/Scripts/Drawers/NumericalAttributeDrawers/ProgressBarDrawer.cs
@@ -32,7 +32,10 @@ namespace EditorAttributes.Editor
                 var propertyValue = GetPropertyValue(property);
 
                 progressBar.value = propertyValue;
-                progressBar.title = $"{property.displayName}: {propertyValue}/{progressBarAttribute.MaxValue}";
+                if (progressBarAttribute.HideLabel)
+                    progressBar.title = string.Empty;
+                else
+                    progressBar.title = $"{property.displayName}: {propertyValue}/{progressBarAttribute.MaxValue}";
             }, 30L);
 
             return progressBar;

--- a/Runtime/Scripts/Attributes/NumericalAttributes/ProgressBarAttribute.cs
+++ b/Runtime/Scripts/Attributes/NumericalAttributes/ProgressBarAttribute.cs
@@ -9,13 +9,15 @@ namespace EditorAttributes
     {
 	    public float MaxValue { get; private set; }
 		public float BarHeight { get; private set; }
+		public bool HideLabel { get; private set; }
 
-		/// <summary>
-		/// Attribute to draw a progress bar
-		/// </summary>
-		/// <param name="maxValue">The maximum value of the progress bar</param>
-		/// <param name="barHeight">The height of the progress bar in pixels</param>
-		public ProgressBarAttribute(float maxValue = 100f, float barHeight = 20f)
+        /// <summary>
+        /// Attribute to draw a progress bar
+        /// </summary>
+        /// <param name="maxValue">The maximum value of the progress bar</param>
+        /// <param name="barHeight">The height of the progress bar in pixels</param>
+        /// <param name="hideLabel">Hides the text inside the progress bar</param>
+        public ProgressBarAttribute(float maxValue = 100f, float barHeight = 20f, bool hideLabel = false)
 		{
 			MaxValue = maxValue;
 			BarHeight = barHeight;


### PR DESCRIPTION
Added `HideLabel` property to `ProgressBarAttribute`, and a matching optional parameter to its constructor. When `HideLabel` is true, `progressBar.Title` is set to string.Empty.

An example of a use case would be progress bars with a bar height smaller than progress bar's title height.

<img width="519" height="117" alt="image" src="https://github.com/user-attachments/assets/6f3d450d-f0e4-4120-a0d5-dd203f7e26b8" />


